### PR TITLE
[feat] 회원, 관리자 권한 로직 구현

### DIFF
--- a/DDIS_Project/HELP.md
+++ b/DDIS_Project/HELP.md
@@ -1,0 +1,29 @@
+# Getting Started
+
+### Reference Documentation
+For further reference, please consider the following sections:
+
+* [Official Gradle documentation](https://docs.gradle.org)
+* [Spring Boot Gradle Plugin Reference Guide](https://docs.spring.io/spring-boot/3.4.4/gradle-plugin)
+* [Create an OCI image](https://docs.spring.io/spring-boot/3.4.4/gradle-plugin/packaging-oci-image.html)
+* [Spring Data JDBC](https://docs.spring.io/spring-boot/3.4.4/reference/data/sql.html#data.sql.jdbc)
+* [Spring Data JPA](https://docs.spring.io/spring-boot/3.4.4/reference/data/sql.html#data.sql.jpa-and-spring-data)
+* [Spring Boot DevTools](https://docs.spring.io/spring-boot/3.4.4/reference/using/devtools.html)
+* [MyBatis Framework](https://mybatis.org/spring-boot-starter/mybatis-spring-boot-autoconfigure/)
+* [Spring Web](https://docs.spring.io/spring-boot/3.4.4/reference/web/servlet.html)
+
+### Guides
+The following guides illustrate how to use some features concretely:
+
+* [Using Spring Data JDBC](https://github.com/spring-projects/spring-data-examples/tree/master/jdbc/basics)
+* [Accessing Data with JPA](https://spring.io/guides/gs/accessing-data-jpa/)
+* [MyBatis Quick Start](https://github.com/mybatis/spring-boot-starter/wiki/Quick-Start)
+* [Building a RESTful Web Service](https://spring.io/guides/gs/rest-service/)
+* [Serving Web Content with Spring MVC](https://spring.io/guides/gs/serving-web-content/)
+* [Building REST services with Spring](https://spring.io/guides/tutorials/rest/)
+
+### Additional Links
+These additional references should also help you:
+
+* [Gradle Build Scans – insights for your project's build](https://scans.gradle.com#gradle)
+

--- a/DDIS_Project/build.gradle
+++ b/DDIS_Project/build.gradle
@@ -1,22 +1,22 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.4'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.DDIS.ToDo'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
@@ -24,28 +24,49 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Spring Boot
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-    // Security (필요시 주석 해제)
+    // MyBatis
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+
+    // ModelMapper
+    implementation 'org.modelmapper:modelmapper:3.2.0'
+
+    // WebSocket, Freemarker, WebJars (채팅 관련)
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-freemarker'
+    implementation 'org.webjars.bower:bootstrap:4.3.1'
+    implementation 'org.webjars.bower:vue:2.5.16'
+    implementation 'org.webjars.bower:axios:0.17.1'
+    implementation 'org.webjars:sockjs-client:1.1.2'
+    implementation 'org.webjars:stomp-websocket:2.3.3-1'
+    implementation 'com.google.code.gson:gson:2.8.0'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Devtools
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // MariaDB Driver
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+     // Security (필요시 주석 해제)
      implementation 'org.springframework.boot:spring-boot-starter-security'
      testImplementation 'org.springframework.security:spring-security-test'
 
-    // JWT 관련 라이브러리 (필요시 주석 해제)
+     // JWT 관련 라이브러리 (필요시 주석 해제)
      implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
      implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
      runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-
 }
 
 tasks.named('test') {

--- a/DDIS_Project/build.gradle
+++ b/DDIS_Project/build.gradle
@@ -20,13 +20,15 @@ configurations {
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
     // Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 
     // MyBatis
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
@@ -59,16 +61,16 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-     // Security (필요시 주석 해제)
-     implementation 'org.springframework.boot:spring-boot-starter-security'
-     testImplementation 'org.springframework.security:spring-security-test'
+    // Security (필요시 주석 해제)
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-     // JWT 관련 라이브러리 (필요시 주석 해제)
-     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    // JWT 관련 라이브러리 (필요시 주석 해제)
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/DDIS_Project/src/main/java/com/DDIS/client/Command/application/controller/ClientController.java
+++ b/DDIS_Project/src/main/java/com/DDIS/client/Command/application/controller/ClientController.java
@@ -1,43 +1,43 @@
-//package com.DDIS.client.Command.application.controller;
-//
-//import com.DDIS.client.Command.application.service.ClientService;
-//import com.DDIS.client.Command.domain.vo.LoginRequestVO;
-//import com.DDIS.client.Command.domain.vo.LoginResponseVO;
-//import com.DDIS.client.Command.domain.vo.SignupRequestVO;
-//import com.DDIS.client.Command.domain.vo.SignupResponseVO;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.PostMapping;
-//import org.springframework.web.bind.annotation.RequestBody;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//@RestController
-//@RequestMapping("/clients")
-//@RequiredArgsConstructor
-//public class ClientController {
-//
-//    private final ClientService clientService;
-//
-//    @PostMapping("/signup")
-//    public ResponseEntity<SignupResponseVO> signup(@RequestBody SignupRequestVO request) {
-//        SignupResponseVO response = clientService.signup(request);
-//
-//        if ("이미 존재하는 아이디입니다.".equals(response.getMessage())) {
-//            return ResponseEntity.badRequest().body(response); // 400
-//        }
-//
-//        return ResponseEntity.status(201).body(response); // 201 Created
-//    }
-//
-//    @PostMapping("/login")
-//    public ResponseEntity<LoginResponseVO> login(@RequestBody LoginRequestVO vo) {
-//        LoginResponseVO response = clientService.login(vo);
-//
-//        if (response.getToken() == null) {
-//            return ResponseEntity.status(401).body(response); // 인증 실패
-//        }
-//
-//        return ResponseEntity.ok(response); // 인증 성공
-//    }
-//}
+package com.DDIS.client.Command.application.controller;
+
+import com.DDIS.client.Command.application.service.ClientService;
+import com.DDIS.client.Command.domain.repository.ClientRepository;
+import com.DDIS.client.Command.domain.vo.LoginRequestVO;
+import com.DDIS.client.Command.domain.vo.LoginResponseVO;
+import com.DDIS.client.Command.domain.vo.SignupRequestVO;
+import com.DDIS.client.Command.domain.vo.SignupResponseVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/clients")
+@RequiredArgsConstructor
+public class ClientController {
+
+    private final ClientService clientService;
+    private final ClientRepository clientRepository;
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponseVO> signup(@RequestBody SignupRequestVO vo) {
+        SignupResponseVO response = clientService.signup(vo);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseVO> login(@RequestBody LoginRequestVO vo) {
+        LoginResponseVO response = clientService.login(vo);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/check-id")
+    public ResponseEntity<String> checkClientId(@RequestParam String clientId) {
+        boolean exists = clientRepository.findByClientId(clientId).isPresent();
+        if (exists) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 존재하는 아이디입니다.");
+        } else {
+            return ResponseEntity.ok("사용 가능한 아이디입니다.");
+        }
+    }
+}

--- a/DDIS_Project/src/main/java/com/DDIS/client/Command/application/service/ClientService.java
+++ b/DDIS_Project/src/main/java/com/DDIS/client/Command/application/service/ClientService.java
@@ -9,5 +9,4 @@ public interface ClientService {
     SignupResponseVO signup(SignupRequestVO vo);
 
     LoginResponseVO login(LoginRequestVO requestVO);
-
 }

--- a/DDIS_Project/src/main/java/com/DDIS/client/Command/application/service/ClientServiceImpl.java
+++ b/DDIS_Project/src/main/java/com/DDIS/client/Command/application/service/ClientServiceImpl.java
@@ -1,70 +1,99 @@
-//package com.DDIS.client.Command.application.service;
-//
-//import com.DDIS.client.Command.domain.aggregate.UserEntity;
-//import com.DDIS.client.Command.domain.repository.ClientRepository;
-//import com.DDIS.client.Command.domain.vo.LoginRequestVO;
-//import com.DDIS.client.Command.domain.vo.LoginResponseVO;
-//import com.DDIS.client.Command.domain.vo.SignupRequestVO;
-//import com.DDIS.client.Command.domain.vo.SignupResponseVO;
-//import com.DDIS.security.util.JwtUtil;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.security.crypto.password.PasswordEncoder;
-//import org.springframework.stereotype.Service;
-//
-//import java.util.Optional;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class ClientServiceImpl implements ClientService {
-//
-//    private final ClientRepository clientRepository;
-//    private final PasswordEncoder passwordEncoder;
-//    private final JwtUtil jwtUtil;
-//
-//    @Override
-//    public SignupResponseVO signup(SignupRequestVO vo) {
-//        if (clientRepository.findByClientId(vo.getClientId()).isPresent()) {
-//            return new SignupResponseVO("이미 존재하는 아이디입니다.");
-//        }
-//
-//        UserEntity user = UserEntity.builder()
-//                .clientName(vo.getClientName())
-//                .clientId(vo.getClientId())
-//                .clientPwd(passwordEncoder.encode(vo.getClientPwd()))
-//                .clientEmail(vo.getClientEmail())
-//                .clientBirth(vo.getClientBirth())
-//                .clientNickname(vo.getClientNickname())
-//                .clientPhotoUrl(vo.getClientPhotoUrl())
-//                .clientType(vo.getClientType())
-//                .clientAccountStatus("ACTIVE")
-//                .clientColorRgb("rgba (80, 212, 198, 100)")
-//                .build();
-//
-//        clientRepository.save(user);
-//
-//        return new SignupResponseVO("회원가입이 성공적으로 완료되었습니다.");
-//    }
-//
-//    @Override
-//    public LoginResponseVO login(LoginRequestVO vo) {
-//        // 사용자 아이디로 조회
-//        Optional<UserEntity> optionalUser = clientRepository.findByClientId(vo.getClientId());
-//
-//        if (optionalUser.isEmpty()) {
-//            return new LoginResponseVO(null, "존재하지 않는 사용자입니다.");
-//        }
-//
-//        UserEntity user = optionalUser.get();
-//
-//        // 비밀번호 검증
-//        if (!passwordEncoder.matches(vo.getClientPwd(), user.getClientPwd())) {
-//            return new LoginResponseVO(null, "비밀번호가 일치하지 않습니다.");
-//        }
-//
-//        // 로그인 성공 → JWT 발급
-//        String token = jwtUtil.generateToken(user.getClientId(), user.getClientType());
-//
-//        return new LoginResponseVO(token, "로그인 성공");
-//    }
-//}
-//
+package com.DDIS.client.Command.application.service;
+
+import com.DDIS.client.Command.domain.aggregate.ClientRoleEntity;
+import com.DDIS.client.Command.domain.aggregate.ClientRoleId;
+import com.DDIS.client.Command.domain.aggregate.RoleEntity;
+import com.DDIS.client.Command.domain.aggregate.UserEntity;
+import com.DDIS.client.Command.domain.repository.ClientRepository;
+import com.DDIS.client.Command.domain.repository.ClientRoleRepository;
+import com.DDIS.client.Command.domain.repository.RoleRepository;
+import com.DDIS.client.Command.domain.vo.LoginRequestVO;
+import com.DDIS.client.Command.domain.vo.LoginResponseVO;
+import com.DDIS.client.Command.domain.vo.SignupRequestVO;
+import com.DDIS.client.Command.domain.vo.SignupResponseVO;
+import com.DDIS.security.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ClientServiceImpl implements ClientService {
+
+    private final ClientRepository clientRepository;
+    private final RoleRepository roleRepository;
+    private final ClientRoleRepository clientRoleRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public SignupResponseVO signup(SignupRequestVO vo) {
+        if (clientRepository.findByClientId(vo.getClientId()).isPresent()) {
+            return new SignupResponseVO("이미 존재하는 아이디입니다.");
+        }
+
+        if (!isValidPassword(vo.getClientPwd())) {
+            return new SignupResponseVO("비밀번호는 대소문자와 숫자를 포함해 8자리 이상이어야 합니다.");
+        }
+
+        UserEntity user = UserEntity.builder()
+                .clientName(vo.getClientName())
+                .clientId(vo.getClientId())
+                .clientPwd(passwordEncoder.encode(vo.getClientPwd()))
+                .clientEmail(vo.getClientEmail())
+                .clientBirth(vo.getClientBirth())
+                .clientNickname(vo.getClientNickname())
+                .clientPhotoUrl(vo.getClientPhotoUrl())
+                .clientType(vo.getClientType())
+                .clientAccountStatus("ACTIVE")
+                .clientColorRgb("rgba (80, 212, 198, 100)")
+                .build();
+
+        UserEntity savedUser = clientRepository.save(user);
+
+        int roleNum = "ADMIN".equalsIgnoreCase(vo.getClientType()) ? 2 : 1;
+        RoleEntity role = roleRepository.findById(roleNum)
+                .orElseThrow(() -> new RuntimeException("권한이 존재하지 않습니다."));
+
+        ClientRoleId id = new ClientRoleId();
+        id.setClientNum(savedUser.getClientNum());
+        id.setRoleNum(role.getRoleNum());
+
+        ClientRoleEntity clientRole = new ClientRoleEntity();
+        clientRole.setId(id);
+        clientRole.setUser(savedUser);
+        clientRole.setRole(role);
+
+        clientRoleRepository.save(clientRole);
+
+        return new SignupResponseVO("회원가입이 성공적으로 완료되었습니다.");
+    }
+
+    @Override
+    public LoginResponseVO login(LoginRequestVO vo) {
+        Optional<UserEntity> optionalUser = clientRepository.findByClientId(vo.getClientId());
+
+        if (optionalUser.isEmpty()) {
+            return new LoginResponseVO(null, "존재하지 않는 사용자입니다.");
+        }
+
+        UserEntity user = optionalUser.get();
+
+        if (!passwordEncoder.matches(vo.getClientPwd(), user.getClientPwd())) {
+            return new LoginResponseVO(null, "비밀번호가 일치하지 않습니다.");
+        }
+
+        String token = jwtUtil.generateToken(user.getClientId(), user.getClientType());
+
+        return new LoginResponseVO(token, "로그인 성공");
+    }
+
+    // 비밀번호 유효성 검사 메서드
+    private boolean isValidPassword(String password) {
+        String regex = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[A-Za-z\\d]{8,}$";
+        return password.matches(regex);
+    }
+}
+

--- a/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/aggregate/ClientRoleEntity.java
+++ b/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/aggregate/ClientRoleEntity.java
@@ -1,0 +1,27 @@
+package com.DDIS.client.Command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "client_roles")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ClientRoleEntity {
+
+    @EmbeddedId
+    private ClientRoleId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("clientNum")
+    @JoinColumn(name = "client_num")
+    private UserEntity user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("roleNum")
+    @JoinColumn(name = "role_num")
+    private RoleEntity role;
+}

--- a/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/aggregate/ClientRoleId.java
+++ b/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/aggregate/ClientRoleId.java
@@ -1,0 +1,19 @@
+package com.DDIS.client.Command.domain.aggregate;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@EqualsAndHashCode
+public class ClientRoleId implements Serializable {
+    private Long clientNum;
+    private Integer roleNum;
+}

--- a/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/aggregate/RoleEntity.java
+++ b/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/aggregate/RoleEntity.java
@@ -1,0 +1,27 @@
+package com.DDIS.client.Command.domain.aggregate;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Table(name = "roles")
+@Getter
+@Setter
+@NoArgsConstructor
+public class RoleEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer roleNum;
+
+    @Column(nullable = false)
+    private String roleName; // 예: ROLE_USER, ROLE_ADMIN
+
+    @OneToMany(mappedBy = "role")
+    private List<ClientRoleEntity> clientRoles;
+}

--- a/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/aggregate/UserEntity.java
+++ b/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/aggregate/UserEntity.java
@@ -3,6 +3,9 @@ package com.DDIS.client.Command.domain.aggregate;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "clients")
 @Getter
@@ -49,4 +52,7 @@ public class UserEntity {
 
     @Column(name = "client_color_rgb", nullable = false)
     private String clientColorRgb = "rgba (80, 212, 198, 100)";
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<ClientRoleEntity> clientRoles = new ArrayList<>();
 }

--- a/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/config/AppConfig.java
+++ b/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/config/AppConfig.java
@@ -1,14 +1,14 @@
-//package com.DDIS.client.Command.domain.config;
-//
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-//import org.springframework.security.crypto.password.PasswordEncoder;
-//
-//@Configuration
-//public class AppConfig {
-//    @Bean
-//    public PasswordEncoder passwordEncoder() {
-//        return new BCryptPasswordEncoder();         // service 계층에서 평문을 꺼낸 후 넣기 위한 bean
-//    }
-//}
+package com.DDIS.client.Command.domain.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();         // service 계층에서 평문을 꺼낸 후 넣기 위한 bean
+    }
+}

--- a/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/repository/ClientRoleRepository.java
+++ b/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/repository/ClientRoleRepository.java
@@ -1,0 +1,7 @@
+package com.DDIS.client.Command.domain.repository;
+
+import com.DDIS.client.Command.domain.aggregate.ClientRoleEntity;
+import com.DDIS.client.Command.domain.aggregate.ClientRoleId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClientRoleRepository extends JpaRepository<ClientRoleEntity, ClientRoleId> {}

--- a/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/repository/RoleRepository.java
+++ b/DDIS_Project/src/main/java/com/DDIS/client/Command/domain/repository/RoleRepository.java
@@ -1,0 +1,6 @@
+package com.DDIS.client.Command.domain.repository;
+
+import com.DDIS.client.Command.domain.aggregate.RoleEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<RoleEntity, Integer> {}

--- a/DDIS_Project/src/main/java/com/DDIS/security/config/SecurityConfig.java
+++ b/DDIS_Project/src/main/java/com/DDIS/security/config/SecurityConfig.java
@@ -1,28 +1,28 @@
-//package com.DDIS.security.config;
-//
-//import com.DDIS.security.filter.JwtAuthenticationFilter;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-//import org.springframework.security.web.SecurityFilterChain;
-//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-//import org.springframework.security.crypto.password.PasswordEncoder;
-//import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-//
-//@Configuration
-//public class SecurityConfig {
-//
-//    @Bean
-//    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws Exception {
-//        http
-//                .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (REST API용)
-//                .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers("/clients/signup", "/clients/login","/**").permitAll() // 인증 없이 허용
-//                        .anyRequest().authenticated() // 나머지는 인증 필요
-//                )
-//                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class) // JWT 필터 등록
-//                .formLogin(login -> login.disable()); // 기본 로그인 화면 비활성화
-//
-//        return http.build();
-//    }
-//}
+package com.DDIS.security.config;
+
+import com.DDIS.security.filter.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (REST API용)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/clients/signup", "/clients/login","/**").permitAll() // 인증 없이 허용
+                        .anyRequest().authenticated() // 나머지는 인증 필요
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class) // JWT 필터 등록
+                .formLogin(login -> login.disable()); // 기본 로그인 화면 비활성화
+
+        return http.build();
+    }
+}

--- a/DDIS_Project/src/main/java/com/DDIS/security/filter/JwtAuthenticationFilter.java
+++ b/DDIS_Project/src/main/java/com/DDIS/security/filter/JwtAuthenticationFilter.java
@@ -1,49 +1,49 @@
-//package com.DDIS.security.filter;
-//
-//import com.DDIS.security.util.JwtUtil;
-//import jakarta.servlet.*;
-//import jakarta.servlet.http.HttpServletRequest;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-//import org.springframework.security.core.context.SecurityContextHolder;
-//import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-//import org.springframework.stereotype.Component;
-//
-//import java.io.IOException;
-//
-//@Component
-//@RequiredArgsConstructor
-//public class JwtAuthenticationFilter extends GenericFilter {
-//
-//    private final JwtUtil jwtUtil;
-//
-//    @Override
-//    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-//            throws IOException, ServletException {
-//
-//        HttpServletRequest httpRequest = (HttpServletRequest) request;
-//
-//        // Authorization 헤더에서 JWT 추출
-//        String token = httpRequest.getHeader("Authorization");
-//
-//        if (token != null && token.startsWith("Bearer ")) {
-//            token = token.substring(7); // "Bearer " 제거
-//
-//            if (jwtUtil.validateToken(token)) {
-//                String clientId = jwtUtil.getClientId(token);
-//
-//                // 사용자 인증 객체 생성
-//                UsernamePasswordAuthenticationToken auth =
-//                        new UsernamePasswordAuthenticationToken(clientId, null, null);
-//
-//                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(httpRequest));
-//
-//                // SecurityContext에 인증 정보 저장
-//                SecurityContextHolder.getContext().setAuthentication(auth);
-//            }
-//        }
-//
-//        // 필터 체인 계속 실행
-//        chain.doFilter(request, response);
-//    }
-//}
+package com.DDIS.security.filter;
+
+import com.DDIS.security.util.JwtUtil;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+        // Authorization 헤더에서 JWT 추출
+        String token = httpRequest.getHeader("Authorization");
+
+        if (token != null && token.startsWith("Bearer ")) {
+            token = token.substring(7); // "Bearer " 제거
+
+            if (jwtUtil.validateToken(token)) {
+                String clientId = jwtUtil.getClientId(token);
+
+                // 사용자 인증 객체 생성
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(clientId, null, null);
+
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(httpRequest));
+
+                // SecurityContext에 인증 정보 저장
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+
+        // 필터 체인 계속 실행
+        chain.doFilter(request, response);
+    }
+}

--- a/DDIS_Project/src/main/java/com/DDIS/security/util/JwtUtil.java
+++ b/DDIS_Project/src/main/java/com/DDIS/security/util/JwtUtil.java
@@ -1,45 +1,43 @@
-//package com.DDIS.security.util;
-//
-//import io.jsonwebtoken.*;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.stereotype.Component;
-//import java.util.Date;
-//
-//@Component
-//public class JwtUtil {
-//
-//    private final String secret;
-//    private final long expiration;
-//
-//    public JwtUtil(@Value("${token.secret}") String secret,
-//                   @Value("${token.expiration_time}") long expiration) {
-//        System.out.println("JWT Secret: " + secret);
-//        System.out.println("JWT Expiration: " + expiration);
-//        this.secret = secret;
-//        this.expiration = expiration;
-//    }
-//
-//    public String generateToken(String clientId, String role) {
-//        return Jwts.builder()
-//                .setSubject(clientId)
-//                .claim("role", role)
-//                .setExpiration(new Date(System.currentTimeMillis() + expiration))
-//                .signWith(SignatureAlgorithm.HS256, secret.getBytes())
-//                .compact();
-//    }
-//
-//    public boolean validateToken(String token) {
-//        try {
-//            Jwts.parserBuilder().setSigningKey(secret.getBytes()).build()
-//                    .parseClaimsJws(token);
-//            return true;
-//        } catch (JwtException e) {
-//            return false;
-//        }
-//    }
-//
-//    public String getClientId(String token) {
-//        return Jwts.parserBuilder().setSigningKey(secret.getBytes()).build()
-//                .parseClaimsJws(token).getBody().getSubject();
-//    }
-//}
+package com.DDIS.security.util;
+
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final String secret;
+    private final long expiration;
+
+    public JwtUtil(@Value("${token.secret}") String secret,
+                   @Value("${token.expiration_time}") long expiration) {
+        this.secret = secret;
+        this.expiration = expiration;
+    }
+
+    public String generateToken(String clientId, String role) {
+        return Jwts.builder()
+                .setSubject(clientId)
+                .claim("role", role)
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(SignatureAlgorithm.HS256, secret.getBytes())
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(secret.getBytes()).build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    public String getClientId(String token) {
+        return Jwts.parserBuilder().setSigningKey(secret.getBytes()).build()
+                .parseClaimsJws(token).getBody().getSubject();
+    }
+}


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 회원가입 시 회원 or 관리자의 권한을 부여합니다.
> 중복 아이디 검사 API를 구현합니다.
> 비밀번호 유효성 검사를 합니다.

## 📌 변경 사항 (Changes)
- [ ] 회원가입 시 clientDB에 insert 동시에 client_roleDB도 insert ex) 회원번호 23 추가 시, 회원별 권한 DB에 1, 23 이렇게 추가 
- [ ] 회원가입 시 중복 아이디가 있을 경우 회원가입 X, 중복 아이디가 있다는 메세지를 띄움.
- [ ] 대소문자와 숫자를 포함하여 8자 이상 비밀번호를 설정하지 않을 시 회원가입 불가 

## 📂 관련 이슈 (Issue)
- close #16 

## ✅ 체크리스트 (Checklist)
- [ ] 회원, 관리자 권한 부여 로직 구현 
- [ ] REST API 
- [ ] POSTMAN으로 API 테스트
- [ ] DB에 올바르게 insert 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어 주세요. (예: 기술적 의사 결정, 고려사항 등)
![check_id API test](https://github.com/user-attachments/assets/407efdc8-e5f6-438f-bbff-022298897941)
![check_id(fail) API test](https://github.com/user-attachments/assets/9438f495-b536-4de7-a7e0-750924d21437)
![give_role_check_db 2](https://github.com/user-attachments/assets/d5a04e53-29de-4b10-951d-c96ed181d1ef)
![give_role_check_db](https://github.com/user-attachments/assets/df2990c6-f55f-4f1b-b420-c183847ce3d5)
![passwordvalidcheck (fail) API test](https://github.com/user-attachments/assets/41452bc7-76b7-44c1-8000-74cb947df90c)
![passwordvalidcheck API test](https://github.com/user-attachments/assets/2fd4ed51-50f1-48e9-9bcd-fdf473dd577c)
