### PR TITLE
[feat] 이메일 인증 로직 구현

### DIFF
--- a/DDIS_Project/build.gradle
+++ b/DDIS_Project/build.gradle
@@ -67,16 +67,22 @@ dependencies {
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-// Security (필요시 주석 해제)
+	// Security (필요시 주석 해제)
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 
-// JWT 관련 라이브러리 (필요시 주석 해제)
+	// JWT 관련 라이브러리 (필요시 주석 해제)
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Redis 디펜던시 추가
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// email authentication (SMTP 기반 이메일 전송 기능 제공)
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 }
 

--- a/DDIS_Project/src/main/java/com/DDIS/email/EmailController.java
+++ b/DDIS_Project/src/main/java/com/DDIS/email/EmailController.java
@@ -1,0 +1,34 @@
+package com.DDIS.email;
+
+import com.DDIS.email.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/email")
+@RequiredArgsConstructor
+public class EmailController {
+
+    private final EmailService emailService;
+
+    // 이메일로 인증번호 발송
+    @PostMapping("/send-code")
+    public ResponseEntity<String> sendVerificationCode(@RequestParam String email) {
+        emailService.sendVerificationCode(email);
+        return ResponseEntity.ok("인증번호를 이메일로 전송했습니다.");
+    }
+
+    // 인증번호 확인
+    @PostMapping("/verify-code")
+    public ResponseEntity<String> verifyCode(@RequestParam String email, @RequestParam String code) {
+        boolean result = emailService.verifyCode(email, code);
+
+        if (result) {
+            return ResponseEntity.ok("이메일 인증 성공!");
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("인증번호가 일치하지 않습니다.");
+        }
+    }
+}

--- a/DDIS_Project/src/main/java/com/DDIS/email/EmailService.java
+++ b/DDIS_Project/src/main/java/com/DDIS/email/EmailService.java
@@ -1,0 +1,6 @@
+package com.DDIS.email;
+
+public interface EmailService {
+        void sendVerificationCode(String email);  // 이메일로 인증번호 보내기
+        boolean verifyCode(String email, String code);  // 인증번호 검증
+}

--- a/DDIS_Project/src/main/java/com/DDIS/email/EmailServiceImpl.java
+++ b/DDIS_Project/src/main/java/com/DDIS/email/EmailServiceImpl.java
@@ -1,0 +1,52 @@
+package com.DDIS.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void sendVerificationCode(String email) {
+        // 1. 인증번호 생성
+        String code = generateRandomCode();
+
+        // 2. Redis에 email -> code 저장 (TTL: 3분)
+        redisTemplate.opsForValue().set(email, code, 3, TimeUnit.MINUTES);
+
+        // 3. 메일 발송
+        sendEmail(email, code);
+    }
+
+    @Override
+    public boolean verifyCode(String email, String code) {
+        String savedCode = redisTemplate.opsForValue().get(email);
+
+        // Redis에 저장된 인증번호가 존재하고, 입력값과 같으면 true
+        return savedCode != null && savedCode.equals(code);
+    }
+
+    private String generateRandomCode() {
+        Random random = new Random();
+        int number = random.nextInt(900000) + 100000; // 6자리 랜덤 숫자
+        return String.valueOf(number);
+    }
+
+    private void sendEmail(String email, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("[DDIS] 이메일 인증번호입니다.");
+        message.setText("당신의 인증번호는 " + code + " 입니다.\n3분 안에 입력해주세요!");
+        mailSender.send(message);
+    }
+}

--- a/DDIS_Project/src/main/java/com/DDIS/email/RedisConfig.java
+++ b/DDIS_Project/src/main/java/com/DDIS/email/RedisConfig.java
@@ -1,0 +1,14 @@
+package com.DDIS.email;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이메일 인증 로직을 구현.

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- close #61 

## ✅ 체크리스트 (Checklist)
- [x] 이메일 인증 로직 확인
- [x] Redis, SMTP 사용
- [x] POSTMAN API 테스트
 
## 💡 추가 설명 (Additional Info)
![check_google](https://github.com/user-attachments/assets/3f3cf53c-5540-495e-9f74-754f0492c4f9)
![email-send](https://github.com/user-attachments/assets/a7fb47a9-cf5a-48fb-82cd-d07ad68753dc)
![email-validation-check](https://github.com/user-attachments/assets/3b3359a9-49c9-4634-b87f-beefef2afca0)

