### PR TITLE
[feat] 회원가입 시 이메일 인증 필요 구현

### DIFF
--- a/DDIS_Project/src/main/java/com/DDIS/email/EmailServiceImpl.java
+++ b/DDIS_Project/src/main/java/com/DDIS/email/EmailServiceImpl.java
@@ -21,8 +21,8 @@ public class EmailServiceImpl implements EmailService {
         // 1. 인증번호 생성
         String code = generateRandomCode();
 
-        // 2. Redis에 email -> code 저장 (TTL: 3분)
-        redisTemplate.opsForValue().set(email, code, 3, TimeUnit.MINUTES);
+        // 2. Redis에 email -> code 저장 (TTL: 5분)
+        redisTemplate.opsForValue().set(email, code, 5, TimeUnit.MINUTES);
 
         // 3. 메일 발송
         sendEmail(email, code);
@@ -32,8 +32,12 @@ public class EmailServiceImpl implements EmailService {
     public boolean verifyCode(String email, String code) {
         String savedCode = redisTemplate.opsForValue().get(email);
 
-        // Redis에 저장된 인증번호가 존재하고, 입력값과 같으면 true
-        return savedCode != null && savedCode.equals(code);
+        if (savedCode != null && savedCode.equals(code)) {
+            // 인증 성공 시, verified 상태로 Redis에 다시 저장
+            redisTemplate.opsForValue().set("verified:" + email, "true", 10, TimeUnit.MINUTES);
+            return true;
+        }
+        return false;
     }
 
     private String generateRandomCode() {

--- a/DDIS_Project/src/main/java/com/DDIS/email/RedisConfig.java
+++ b/DDIS_Project/src/main/java/com/DDIS/email/RedisConfig.java
@@ -1,9 +1,11 @@
 package com.DDIS.email;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
+@Configuration
 public class RedisConfig {
     @Bean
     public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 회원가입 시 이메일 인증 필요로 하게 구현

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- close #63 

## ✅ 체크리스트 (Checklist)
- [ ] 이메일 인증을 한 이메일만 회원가입 가능하게 함
- [ ]  Postman API 테스트
- [ ]  REST API 

## 💡 추가 설명 (Additional Info)
![email-authentication](https://github.com/user-attachments/assets/355d3b1a-40aa-4030-89ff-86516fb41abe)
이메일 인증 후 
![success](https://github.com/user-attachments/assets/6f4d8947-9921-4860-a571-f7c93be26102)
회원가입 가능
![fail](https://github.com/user-attachments/assets/917ebf61-a0fe-43f2-a891-8264fa70c397)
이메일 인증 실패 시 불가능

