### PR TITLE
[FEAT] 모집게시글 모집 마감시 공동 todo방 생성 버튼 활성화 로직 구현

### DIFF
--- a/DDIS_Project/src/main/java/com/DDIS/post/Command/application/service/PostServiceImpl.java
+++ b/DDIS_Project/src/main/java/com/DDIS/post/Command/application/service/PostServiceImpl.java
@@ -88,12 +88,11 @@ public class PostServiceImpl implements PostService {
                 .clientNum(client)
                 .applicantCount(0)
                 .isClosed(false)
-                .createdDate(nowDateTime) // ✅ createdDate 추가
+                .createdDate(nowDateTime)
                 .build();
 
         postRepository.save(post);
     }
-
 
     // 3. 모집게시글 수정
     @Override
@@ -102,14 +101,15 @@ public class PostServiceImpl implements PostService {
         Post post = postRepository.findById(postNum)
                 .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
 
-        // TODO: 시큐리티 적용 후 작성자 확인 다시 추가
-//    if (!post.getClientNum().getClientNum().equals(requesterId)) {
-//        throw new RuntimeException("작성자만 수정할 수 있습니다.");
-//    }
+        // 모집 마감 여부 체크
+        if (Boolean.TRUE.equals(post.getIsClosed())) {
+            throw new RuntimeException("모집이 마감된 게시글은 수정할 수 없습니다.");
+        }
 
+        // 게시글 수정
         post.updatePost(request.getPostTitle(), request.getPostContent());
 
-        // ✅ 수정 시간 (updatedDate) 세팅
+        // 수정일 업데이트
         String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         post.setUpdatedDate(now);
     }

--- a/DDIS_Project/src/main/java/com/DDIS/post/Query/controller/PostController.java
+++ b/DDIS_Project/src/main/java/com/DDIS/post/Query/controller/PostController.java
@@ -2,14 +2,12 @@
 package com.DDIS.post.Query.controller;
 
 import com.DDIS.post.Query.dto.AdminPostDTO;
+import com.DDIS.post.Query.dto.PostCloseResponseDTO;
 import com.DDIS.post.Query.dto.PublicPostDTO;
 import com.DDIS.post.Query.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -66,5 +64,13 @@ public class PostController {
 
         return ResponseEntity.ok(posts); // 200 OK
     }
+
+    // 5. 방장이 글 조회할 때 호출
+     @GetMapping("/{postNum}/check-close")
+        public PostCloseResponseDTO checkPostCloseStatus(
+                @PathVariable Long postNum,
+                @RequestParam Long clientNum) {
+            return postService.checkAndClosePost(postNum, clientNum);
+        }
 
 }

--- a/DDIS_Project/src/main/java/com/DDIS/post/Query/dto/PostCloseResponseDTO.java
+++ b/DDIS_Project/src/main/java/com/DDIS/post/Query/dto/PostCloseResponseDTO.java
@@ -1,0 +1,14 @@
+package com.DDIS.post.Query.dto;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class PostCloseResponseDTO {
+    private Long postNum;
+    private Boolean isClosed;
+}

--- a/DDIS_Project/src/main/java/com/DDIS/post/Query/dto/PostCreateTodoRoomDTO.java
+++ b/DDIS_Project/src/main/java/com/DDIS/post/Query/dto/PostCreateTodoRoomDTO.java
@@ -1,0 +1,20 @@
+package com.DDIS.post.Query.dto;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class PostCreateTodoRoomDTO {
+
+        private Long postNum;
+        private Long clientNum;
+        private String recruitmentEndDate;
+        private Integer recruitmentLimit;
+        private Integer applicantCount;
+        private Boolean isClosed;
+
+}

--- a/DDIS_Project/src/main/java/com/DDIS/post/Query/mapper/PostMapper.java
+++ b/DDIS_Project/src/main/java/com/DDIS/post/Query/mapper/PostMapper.java
@@ -3,6 +3,7 @@
 package com.DDIS.post.Query.mapper;
 
 import com.DDIS.post.Query.dto.AdminPostDTO;
+import com.DDIS.post.Query.dto.PostCreateTodoRoomDTO;
 import com.DDIS.post.Query.dto.PublicPostDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -23,5 +24,9 @@ public interface PostMapper {
 
     // 4. 등록일 최신순 조회
     List<PublicPostDTO> findPostsOrderByStartDateDesc();
+
+    // 5. 작성자 공동방 생성
+    PostCreateTodoRoomDTO findPostById(Long postNum);
+    void closePost(Long postNum);
 
 }

--- a/DDIS_Project/src/main/java/com/DDIS/post/Query/service/PostService.java
+++ b/DDIS_Project/src/main/java/com/DDIS/post/Query/service/PostService.java
@@ -1,6 +1,7 @@
 package com.DDIS.post.Query.service;
 
 import com.DDIS.post.Query.dto.AdminPostDTO;
+import com.DDIS.post.Query.dto.PostCloseResponseDTO;
 import com.DDIS.post.Query.dto.PublicPostDTO;
 
 import java.util.List;
@@ -18,5 +19,8 @@ public interface PostService {
 
     // 4. 최신 모집일 기준 정렬 조회
     List<PublicPostDTO> findPostsOrderByStartDateDesc();
+
+    // 5. 방장 공동방 생성을 위한 조회
+    PostCloseResponseDTO checkAndClosePost(Long postNum, Long requesterClientNum);
 
 }

--- a/DDIS_Project/src/main/java/com/DDIS/post/Query/service/PostServiceImpl.java
+++ b/DDIS_Project/src/main/java/com/DDIS/post/Query/service/PostServiceImpl.java
@@ -1,10 +1,16 @@
 package com.DDIS.post.Query.service;
 
 import com.DDIS.post.Query.dto.AdminPostDTO;
+import com.DDIS.post.Query.dto.PostCloseResponseDTO;
+import com.DDIS.post.Query.dto.PostCreateTodoRoomDTO;
 import com.DDIS.post.Query.dto.PublicPostDTO;
 import com.DDIS.post.Query.mapper.PostMapper;
+import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 // 비즈니스 로직 처리
@@ -33,5 +39,46 @@ public class PostServiceImpl implements PostService {
     // 4. 최신 모집일 기준 정렬 조회
     @Override
     public List<PublicPostDTO> findPostsOrderByStartDateDesc() { return postMapper.findPostsOrderByStartDateDesc();}
+
+    // 5. 공동 방 생성을 위한 조회
+    @Override
+    @Transactional
+    public PostCloseResponseDTO checkAndClosePost(Long postNum, Long requesterClientNum) {
+        PostCreateTodoRoomDTO post = postMapper.findPostById(postNum);
+
+        if (post == null) {
+            throw new RuntimeException("게시글이 존재하지 않습니다.");
+        }
+
+        // 본인이 쓴 글인지 확인
+        if (!post.getClientNum().equals(requesterClientNum)) {
+            throw new RuntimeException("본인이 작성한 글만 조회할 수 있습니다.");
+        }
+
+        boolean shouldClose = false;
+
+        // 모집 마감일 체크
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = LocalDate.parse(post.getRecruitmentEndDate(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        if (today.isAfter(endDate)) {
+            shouldClose = true;
+        }
+
+        // 모집 인원 체크
+        if (post.getApplicantCount() != null &&
+                post.getApplicantCount() >= post.getRecruitmentLimit()) {
+            shouldClose = true;
+        }
+
+        // 조건 충족하고, 아직 닫히지 않은 경우
+        if (shouldClose && !post.getIsClosed()) {
+            postMapper.closePost(postNum);
+            return new PostCloseResponseDTO(postNum, true);
+        } else {
+            return new PostCloseResponseDTO(postNum, post.getIsClosed());
+        }
+
+    }
 
 }

--- a/DDIS_Project/src/main/resources/com/DDIS/post/Query/mapper/PostMapper.xml
+++ b/DDIS_Project/src/main/resources/com/DDIS/post/Query/mapper/PostMapper.xml
@@ -138,4 +138,28 @@
         ORDER BY p.recruitment_start_date DESC
     </select>
 
+
+    <!-- 공동방 생성을 위한 방장 조회 -->
+    <!-- 게시글 하나 조회 -->
+    <select id="findPostById" resultType="com.DDIS.post.Query.dto.PostCreateTodoRoomDTO">
+        SELECT
+            post_num,
+            client_num,
+            recruitment_end_date,
+            applicant_count,
+            recruitment_limit,
+            is_closed
+        FROM posts
+        WHERE post_num = #{postNum}
+          AND delete_date IS NULL
+    </select>
+
+    <!-- 모집글 마감 처리 -->
+    <update id="closePost">
+        UPDATE posts
+        SET is_closed = true,
+            updated_date = NOW()
+        WHERE post_num = #{postNum}
+    </update>
+
 </mapper>


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 
사용자(방장)이 모집게시글 조회 시,
둘 중 하나의 조건 만족하는 경우 모집마감상태 true 변경 후 추후 인원 모집 불가

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- close #74 

## ✅ 체크리스트 (Checklist)
- [x] 코드에 오류가 없는지 확인하셨나요?
- [x] 주요 변경 사항을 문서화하셨나요?
- [ ] 단위 테스트 또는 통합 테스트를 추가했나요? (해당하는 경우)
- [ ] 리뷰어가 확인해야 할 포인트가 있다면 적어 주세요.

## 💡 추가 설명 (Additional Info)
> 모집 마감상태 false인 경우(vue에서 공동 todo방 생성 버튼 비활성화)

<img width="859" alt="image" src="https://github.com/user-attachments/assets/44064212-9642-4757-b360-0d83fac2dc9f" />


> 모집 마감상태 true인 경우 (마감 조건 충족 시 isClosed 자동 업데이트)

<img width="855" alt="image" src="https://github.com/user-attachments/assets/f9d7bf87-53ed-494e-bd50-511e0697ce92" />

