### PR TITLE
[FEAT] 인증 실패/ 권한 실패 핸들러 추가

### DIFF
--- a/DDIS_Project/src/main/java/com/DDIS/security/JwtAccessDeniedHandler.java
+++ b/DDIS_Project/src/main/java/com/DDIS/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,25 @@
+package com.DDIS.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
+        response.getWriter().write("{\"message\": \"권한이 부족합니다.\"}");
+    }
+}

--- a/DDIS_Project/src/main/java/com/DDIS/security/JwtAuthenticationEntryPoint.java
+++ b/DDIS_Project/src/main/java/com/DDIS/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package com.DDIS.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException)
+            throws IOException, ServletException {
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.getWriter().write("{\"message\": \"인증이 필요합니다.\"}");
+    }
+}

--- a/DDIS_Project/src/main/java/com/DDIS/security/config/SecurityConfig.java
+++ b/DDIS_Project/src/main/java/com/DDIS/security/config/SecurityConfig.java
@@ -1,30 +1,54 @@
 package com.DDIS.security.config;
 
+import com.DDIS.security.JwtAccessDeniedHandler;
+import com.DDIS.security.JwtAuthenticationEntryPoint;
 import com.DDIS.security.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-
-// JWT 필터 등록 및 설정
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (REST API용)
+                .csrf(csrf -> csrf.disable()) // CSRF 끄기 (REST API라서)
+
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)      // 인증 실패 처리
+                        .accessDeniedHandler(jwtAccessDeniedHandler))               // 권한 실패 처리
+
+                .sessionManagement(sessionManagement -> sessionManagement
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))    // 세션 사용 안 함
+
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/clients/signup", "/clients/login","/**").permitAll() // 인증 없이 허용
-                        .anyRequest().authenticated() // 나머지는 인증 필요
-                )
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class) // JWT 필터 등록
-                .formLogin(login -> login.disable()); // 기본 로그인 화면 비활성화
+                        .requestMatchers("/clients/signup", "/clients/login").permitAll()
+                                                                                    // 회원가입, 로그인만 인증 없이 허용
+                        .anyRequest().authenticated())                              // 나머지는 인증 필요
+
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                // JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 등록
+
+                .formLogin(formLogin -> formLogin.disable()); // 기본 로그인 폼 비활성화
 
         return http.build();
     }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }
+


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 인증 실패/ 권한 실패 핸들러 기능을 추가했습니다. 

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- close #80 

## ✅ 체크리스트 (Checklist)
- [x] 코드에 오류가 없는지 확인하셨나요?
- [ ] 주요 변경 사항을 문서화하셨나요?
- [ ] 단위 테스트 또는 통합 테스트를 추가했나요? (해당하는 경우)
- [ ] 리뷰어가 확인해야 할 포인트가 있다면 적어 주세요.

## 💡 추가 설명 (Additional Info)
> 로그인 안 된 회원에게 401에러로 "인증이 필요합니다." 메세지 출력
> 권한이 없는 회원에게 403에러로 "권한이 부족합니다." 메세지 출력
